### PR TITLE
Fix import path

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,7 +3,6 @@ use crate::{
 	substitute::{substitute, Substitution},
 };
 use proc_macro::{token_stream::IntoIter, Span, TokenStream, TokenTree};
-use proc_macro_error::*;
 use std::{
 	collections::{HashMap, HashSet},
 	iter::Peekable,

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,8 +1,5 @@
-use proc_macro::{Delimiter, Group, Span, TokenTree};
-use proc_macro_error::{
-	proc_macro::{Punct, Spacing},
-	*,
-};
+use proc_macro::{Delimiter, Group, Punct, Spacing, Span, TokenTree};
+use proc_macro_error::*;
 
 /// Tries to parse a valid group from the given token stream iterator, returning
 /// the group if successful.

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,5 +1,4 @@
 use proc_macro::{Delimiter, Group, Punct, Spacing, Span, TokenTree};
-use proc_macro_error::*;
 
 /// Tries to parse a valid group from the given token stream iterator, returning
 /// the group if successful.


### PR DESCRIPTION
Fixes #11 

This applies the patch mentioned there. Also, I turns out that `use proc_macro_error::*` was unnecessary in two of the modules, so I removed those as well.