### PR TITLE
MSRV: Make the code buildable on Rust 1.34

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,8 @@
 //! APIs might use this macro to test them without having to copy-paste test
 //! cases and manually make the needed edits.
 
+extern crate proc_macro;
+
 mod crate_readme_test;
 #[cfg(feature = "module_disambiguation")]
 mod module_disambiguation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -970,7 +970,8 @@ fn duplicate_impl(attr: TokenStream, item: TokenStream) -> Result<TokenStream, (
 ///
 /// The `pretty_errors` feature can be enabled, the span is shown
 /// with the error message.
-fn abort(#[allow(unused_variables)] span: Span, msg: &str) -> !
+#[allow(unused_variables)]
+fn abort(span: Span, msg: &str) -> !
 {
 	#[cfg(feature = "pretty_errors")]
 	{

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -54,11 +54,11 @@ fn identify_syntax(attr: TokenStream, stream_span: Span) -> Result<bool, (Span, 
 {
 	if let Some(token) = next_token(&mut attr.into_iter(), "Could not identify syntax type.")?
 	{
-		match token
+		match &token
 		{
 			TokenTree::Group(_) => Ok(true),
 			TokenTree::Ident(_) => Ok(false),
-			TokenTree::Punct(p) if is_nested_invocation(&p) => Ok(true),
+			TokenTree::Punct(p) if is_nested_invocation(p) => Ok(true),
 			_ =>
 			{
 				Err((
@@ -91,9 +91,9 @@ fn validate_verbose_attr(attr: TokenStream) -> Result<Vec<SubstitutionGroup>, (S
 	{
 		if let Some(tree) = next_token(&mut iter, "Expected substitution group.")?
 		{
-			match tree
+			match &tree
 			{
-				TokenTree::Punct(p) if is_nested_invocation(&p) =>
+				TokenTree::Punct(p) if is_nested_invocation(p) =>
 				{
 					let nested_duplicated = invoke_nested(&mut iter, p.span())?;
 					let subs = validate_verbose_attr(nested_duplicated)?;
@@ -243,7 +243,7 @@ fn validate_short_get_identifiers(
 		if let Some(next_token) = next_token(&mut iter, "Expected substitution identifier or ';'.")?
 		{
 			span = next_token.span();
-			match next_token
+			match &next_token
 			{
 				TokenTree::Ident(ident) =>
 				{
@@ -284,7 +284,7 @@ fn validate_short_get_identifier_arguments(
 						result.push(ident.to_string());
 						if let Some(token) = arg_iter.next()
 						{
-							match token
+							match &token
 							{
 								TokenTree::Punct(punct) if punct_is_char(&punct, ',') => (),
 								_ => return Err((token.span(), "Expected ','.".into())),

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -88,19 +88,16 @@ pub fn next_token(
 {
 	match iter.next()
 	{
-		Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::None =>
+		Some(TokenTree::Group(ref group)) if group.delimiter() == Delimiter::None =>
 		{
 			let mut in_group = group.stream().into_iter();
 			let result = in_group.next();
-			match in_group.next()
+			match (in_group.next(), in_group.next())
 			{
-				None => Ok(result),
+				(None, _) => Ok(result),
 				// If ends with ';' and nothing else, was a statement including
 				// only 1 token, so allow.
-				Some(TokenTree::Punct(p)) if is_semicolon(&p) && in_group.next().is_none() =>
-				{
-					Ok(result)
-				},
+				(Some(TokenTree::Punct(ref p)), None) if is_semicolon(&p) => Ok(result),
 				_ => Err((group.span(), err_msg.into())),
 			}
 		},

--- a/src/substitute.rs
+++ b/src/substitute.rs
@@ -67,7 +67,7 @@ impl Substitution
 		{
 			match token
 			{
-				TokenTree::Ident(ident) if find_argument(&ident).is_some() =>
+				TokenTree::Ident(ref ident) if find_argument(&ident).is_some() =>
 				{
 					if let Some(sub_stream) = saved_tokens.take()
 					{


### PR DESCRIPTION
# Rationale
A crate I'm depending on is [about to depend on `duplicate`](https://github.com/rebpf/rebpf/pull/20), and while the changes there seem really nice, I need to be able to build on 1.34.2 (which is the version of Rust shipped on the current Debian Stable).

# Description of the changes
The changes are relatively benign, with only *one* small semantic change, in `parse_utils::next_token`, where in the inner group matching the function now unconditionally pops two values from the iterator instead of just one and "perhaps" another. As the iterator is locally created I don't think it leaks any side effect out of the function.

You'll find some details about what wasn't 1.34-compatible in the commit messages.

# Caveats
To be able to test those changes on 1.34, one need a [patched version](https://github.com/eupn/macrotest/pull/48) of macrotest.
Two tests fail on 1.34, but they fail because it's not possible to apply attributes to modules (module_disambiguation) nor statements (duplicate_inline) in 1.34, not because of the underlying logic of the macro.