### PR TITLE
Update macrotest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = { version = "=1.0.4", optional = true }
 convert_case = { version = "=0.4.0", optional = true } # Must use '=' because of a lack of MSRV
 
 [dev-dependencies]
-macrotest = "=1.0.5" # Must use '=' because of a lack of MSRV
+macrotest = "1"
 doc-comment = "=0.3.3" # Must use '=' because of a lack of MSRV
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = { version = "=1.0.4", optional = true }
 convert_case = { version = "=0.4.0", optional = true } # Must use '=' because of a lack of MSRV
 
 [dev-dependencies]
-macrotest = "1"
+macrotest = "^1.0.7" # MSRV of 1.34 went into effect with this version
 doc-comment = "=0.3.3" # Must use '=' because of a lack of MSRV
 
 [features]


### PR DESCRIPTION
Related to https://github.com/eupn/macrotest/issues/52. The `macrotest v1.0.7` is now supporting Rust 1.34 as a MSRV, so the crate's version could be unpinned in `Cargo.toml`.